### PR TITLE
feat: rapid fire, responsive screen, mobile touch

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Space Invaders</title>
   <style>
-    body {
+    html, body {
       margin: 0;
       background: #000;
-      display: flex;
-      justify-content: center;
-      align-items: center;
-      height: 100vh;
+      height: 100%;
       overflow: hidden;
+    }
+    canvas {
+      touch-action: none;
     }
   </style>
 </head>

--- a/src/actors/player.ts
+++ b/src/actors/player.ts
@@ -5,7 +5,8 @@ import { getSpriteSheet, SpriteIndex } from '../resources';
 import { Bullet } from './bullet';
 
 export class Player extends ex.Actor {
-  private activeBullet: Bullet | null = null;
+  private activeBullets: Bullet[] = [];
+  private fireCooldownTimer: number = 0;
 
   constructor() {
     super({
@@ -17,19 +18,26 @@ export class Player extends ex.Actor {
     });
   }
 
-  onInitialize(): void {
-    const sprite = getSpriteSheet().getSprite(SpriteIndex.player % 8, Math.floor(SpriteIndex.player / 8));
-    if (sprite) this.graphics.use(sprite);
-  }
-
   onPreUpdate(engine: ex.Engine, delta: number): void {
     this.vel.x = 0;
+    this.fireCooldownTimer = Math.max(0, this.fireCooldownTimer - delta);
 
     if (engine.input.keyboard.isHeld(ex.Keys.Left) || engine.input.keyboard.isHeld(ex.Keys.A)) {
       this.vel.x = -CONFIG.player.speed;
     }
     if (engine.input.keyboard.isHeld(ex.Keys.Right) || engine.input.keyboard.isHeld(ex.Keys.D)) {
       this.vel.x = CONFIG.player.speed;
+    }
+
+    // Touch/pointer movement
+    if (engine.input.pointers.isDown(0)) {
+      const pointerX = engine.input.pointers.primary.lastWorldPos.x;
+      const dx = pointerX - this.pos.x;
+      if (dx < -20) {
+        this.vel.x = -CONFIG.player.speed;
+      } else if (dx > 20) {
+        this.vel.x = CONFIG.player.speed;
+      }
     }
 
     // Clamp to screen edges
@@ -42,9 +50,24 @@ export class Player extends ex.Actor {
     }
   }
 
-  private fire(engine: ex.Engine): void {
-    if (this.activeBullet && !this.activeBullet.isKilled()) return;
-    this.activeBullet = new Bullet(ex.vec(this.pos.x, this.pos.y - 16), 'player');
-    engine.add(this.activeBullet);
+  onInitialize(engine: ex.Engine): void {
+    const sprite = getSpriteSheet().getSprite(SpriteIndex.player % 8, Math.floor(SpriteIndex.player / 8));
+    if (sprite) this.graphics.use(sprite);
+
+    // Touch/click fires
+    engine.input.pointers.on('down', () => {
+      this.fire(engine);
+    });
+  }
+
+  fire(engine: ex.Engine): void {
+    if (this.fireCooldownTimer > 0) return;
+    this.activeBullets = this.activeBullets.filter(b => !b.isKilled());
+    if (this.activeBullets.length >= CONFIG.player.maxBullets) return;
+
+    const bullet = new Bullet(ex.vec(this.pos.x, this.pos.y - 16), 'player');
+    this.activeBullets.push(bullet);
+    engine.add(bullet);
+    this.fireCooldownTimer = CONFIG.player.fireCooldown;
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,8 @@ export const CONFIG = {
     respawnTime: 1000,
     invincibilityTime: 2000,
     yPosition: 600,
+    maxBullets: 3,
+    fireCooldown: 150,
   },
   alien: {
     gridRows: 5,

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,7 @@ import { loader } from './resources';
 const game = new ex.Engine({
   width: CONFIG.canvas.width,
   height: CONFIG.canvas.height,
+  displayMode: ex.DisplayMode.FitScreen,
   backgroundColor: ex.Color.fromHex('#0a0a2a'),
 });
 

--- a/src/scenes/game.ts
+++ b/src/scenes/game.ts
@@ -99,6 +99,9 @@ export class GameScene extends ex.Scene {
       if (engine.input.keyboard.wasPressed(ex.Keys.Enter)) {
         this.restart(engine);
       }
+      if (engine.input.pointers.isDragStart(0)) {
+        this.restart(engine);
+      }
       return;
     }
 
@@ -175,7 +178,7 @@ export class GameScene extends ex.Scene {
     this.gameOver = true;
     this.player.kill();
     this.alienGrid.destroy();
-    this.gameOverLabel.text = `GAME OVER\nSCORE: ${this.score}\n\nPress ENTER to restart`;
+    this.gameOverLabel.text = `GAME OVER\nSCORE: ${this.score}\n\nPress ENTER or TAP to restart`;
   }
 
   private restart(engine: ex.Engine): void {


### PR DESCRIPTION
## Summary
- **Rapid fire:** Players can have up to 3 bullets on screen simultaneously with a 150ms cooldown between shots, replacing the sluggish single-bullet system
- **Responsive screen:** Canvas scales to fill the browser window using Excalibur's `DisplayMode.FitScreen`, maintaining the 3:4 aspect ratio with letterboxing — all game logic unchanged
- **Mobile touch controls:** Touch/click moves the player toward the pointer (with 20px dead zone) and fires simultaneously; tap-to-restart on game over screen; `touch-action: none` prevents browser gesture interference

## Test plan
- [ ] Run `npm run build` — compiles with no errors
- [ ] Press Space rapidly — up to 3 bullets visible simultaneously, 150ms cooldown between shots
- [ ] Resize browser window — canvas scales to fill, maintains 3:4 ratio, letterboxes if needed
- [ ] Open DevTools device toolbar (phone simulation) — click/tap to move + fire
- [ ] On game over screen, tap to restart works
- [ ] Keyboard controls (arrows, A/D, Space, Enter) still work identically on desktop