### PR TITLE
feat: Space Invaders with retro sound, screen shake, and mobile controls

### DIFF
--- a/src/actors/alien-grid.ts
+++ b/src/actors/alien-grid.ts
@@ -2,6 +2,7 @@ import * as ex from 'excalibur';
 import { Alien, AlienType } from './alien';
 import { Bullet } from './bullet';
 import { CONFIG } from '../config';
+import { audio } from '../audio';
 
 const ROW_TYPES: AlienType[] = ['squid', 'crab', 'crab', 'octopus', 'octopus'];
 
@@ -72,6 +73,8 @@ export class AlienGrid {
   private step(): void {
     const alive = this.aliens.filter(a => !a.isKilled());
     if (alive.length === 0) return;
+
+    audio.alienStep();
 
     // Toggle animation frame on each step
     alive.forEach(a => a.toggleFrame());

--- a/src/actors/player.ts
+++ b/src/actors/player.ts
@@ -3,11 +3,12 @@ import { CONFIG } from '../config';
 import { PlayerGroup } from '../collision-groups';
 import { getSpriteSheet, SpriteIndex } from '../resources';
 import { Bullet } from './bullet';
+import { audio } from '../audio';
 
 export class Player extends ex.Actor {
   private activeBullets: Bullet[] = [];
   private fireCooldownTimer: number = 0;
-  private pointerHandler: (() => void) | null = null;
+  private pointerHandler: ((evt: ex.PointerEvent) => void) | null = null;
 
   constructor() {
     super({
@@ -23,6 +24,7 @@ export class Player extends ex.Actor {
     this.vel.x = 0;
     this.fireCooldownTimer = Math.max(0, this.fireCooldownTimer - delta);
 
+    // Keyboard movement
     if (engine.input.keyboard.isHeld(ex.Keys.Left) || engine.input.keyboard.isHeld(ex.Keys.A)) {
       this.vel.x = -CONFIG.player.speed;
     }
@@ -30,14 +32,15 @@ export class Player extends ex.Actor {
       this.vel.x = CONFIG.player.speed;
     }
 
-    // Touch/pointer movement
+    // Touch movement: only in the bottom movement zone
     if (engine.input.pointers.isDown(0)) {
-      const pointerX = engine.input.pointers.primary.lastWorldPos.x;
-      const dx = pointerX - this.pos.x;
-      if (dx < -20) {
-        this.vel.x = -CONFIG.player.speed;
-      } else if (dx > 20) {
-        this.vel.x = CONFIG.player.speed;
+      const pointerPos = engine.input.pointers.primary.lastWorldPos;
+      if (pointerPos.y > CONFIG.touch.zoneDivider) {
+        if (pointerPos.x < CONFIG.canvas.width / 2) {
+          this.vel.x = -CONFIG.player.speed;
+        } else {
+          this.vel.x = CONFIG.player.speed;
+        }
       }
     }
 
@@ -46,6 +49,7 @@ export class Player extends ex.Actor {
     if (this.pos.x < halfWidth) this.pos.x = halfWidth;
     if (this.pos.x > CONFIG.canvas.width - halfWidth) this.pos.x = CONFIG.canvas.width - halfWidth;
 
+    // Keyboard fire
     if (engine.input.keyboard.wasPressed(ex.Keys.Space)) {
       this.fire(engine);
     }
@@ -55,9 +59,9 @@ export class Player extends ex.Actor {
     const sprite = getSpriteSheet().getSprite(SpriteIndex.player % 8, Math.floor(SpriteIndex.player / 8));
     if (sprite) this.graphics.use(sprite);
 
-    // Touch/click fires — store handler so we can remove it on kill
-    this.pointerHandler = () => {
-      if (!this.isKilled()) {
+    // Touch fire: only in the game area (above movement zone)
+    this.pointerHandler = (evt: ex.PointerEvent) => {
+      if (!this.isKilled() && evt.worldPos.y <= CONFIG.touch.zoneDivider) {
         this.fire(engine);
       }
     };
@@ -65,7 +69,6 @@ export class Player extends ex.Actor {
   }
 
   onPreKill(): void {
-    // Clean up pointer handler to prevent accumulation across restarts
     if (this.pointerHandler && this.scene?.engine) {
       this.scene.engine.input.pointers.off('down', this.pointerHandler);
       this.pointerHandler = null;
@@ -77,6 +80,7 @@ export class Player extends ex.Actor {
     this.activeBullets = this.activeBullets.filter(b => !b.isKilled());
     if (this.activeBullets.length >= CONFIG.player.maxBullets) return;
 
+    audio.playerShoot();
     const bullet = new Bullet(ex.vec(this.pos.x, this.pos.y - 16), 'player');
     this.activeBullets.push(bullet);
     engine.add(bullet);

--- a/src/audio.ts
+++ b/src/audio.ts
@@ -1,0 +1,143 @@
+// Synthesized retro sound effects using Web Audio API
+// No audio files needed — all sounds generated programmatically
+
+class AudioManager {
+  private static instance: AudioManager;
+  private ctx: AudioContext | null = null;
+  private stepIndex: number = 0;
+
+  static getInstance(): AudioManager {
+    if (!AudioManager.instance) {
+      AudioManager.instance = new AudioManager();
+    }
+    return AudioManager.instance;
+  }
+
+  resume(): void {
+    if (!this.ctx) {
+      this.ctx = new AudioContext();
+    }
+    if (this.ctx.state === 'suspended') {
+      this.ctx.resume();
+    }
+  }
+
+  private getCtx(): AudioContext | null {
+    if (!this.ctx) {
+      this.ctx = new AudioContext();
+    }
+    return this.ctx;
+  }
+
+  playerShoot(): void {
+    const ctx = this.getCtx();
+    if (!ctx) return;
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.type = 'square';
+    osc.frequency.setValueAtTime(900, ctx.currentTime);
+    osc.frequency.exponentialRampToValueAtTime(300, ctx.currentTime + 0.07);
+    gain.gain.setValueAtTime(0.15, ctx.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.07);
+    osc.start(ctx.currentTime);
+    osc.stop(ctx.currentTime + 0.07);
+  }
+
+  alienExplode(): void {
+    const ctx = this.getCtx();
+    if (!ctx) return;
+    // White noise burst for explosion
+    const bufferSize = ctx.sampleRate * 0.15;
+    const buffer = ctx.createBuffer(1, bufferSize, ctx.sampleRate);
+    const data = buffer.getChannelData(0);
+    for (let i = 0; i < bufferSize; i++) {
+      data[i] = (Math.random() * 2 - 1) * (1 - i / bufferSize);
+    }
+    const noise = ctx.createBufferSource();
+    noise.buffer = buffer;
+    const gain = ctx.createGain();
+    noise.connect(gain);
+    gain.connect(ctx.destination);
+    gain.gain.setValueAtTime(0.2, ctx.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.15);
+    noise.start(ctx.currentTime);
+  }
+
+  playerHit(): void {
+    const ctx = this.getCtx();
+    if (!ctx) return;
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.type = 'sawtooth';
+    osc.frequency.setValueAtTime(400, ctx.currentTime);
+    osc.frequency.exponentialRampToValueAtTime(100, ctx.currentTime + 0.2);
+    gain.gain.setValueAtTime(0.15, ctx.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.2);
+    osc.start(ctx.currentTime);
+    osc.stop(ctx.currentTime + 0.2);
+  }
+
+  playerDeath(): void {
+    const ctx = this.getCtx();
+    if (!ctx) return;
+    // Cascading descending tones
+    for (let i = 0; i < 4; i++) {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.type = 'square';
+      const startTime = ctx.currentTime + i * 0.12;
+      osc.frequency.setValueAtTime(600 - i * 120, startTime);
+      osc.frequency.exponentialRampToValueAtTime(50, startTime + 0.12);
+      gain.gain.setValueAtTime(0.15, startTime);
+      gain.gain.exponentialRampToValueAtTime(0.001, startTime + 0.12);
+      osc.start(startTime);
+      osc.stop(startTime + 0.12);
+    }
+  }
+
+  alienStep(): void {
+    const ctx = this.getCtx();
+    if (!ctx) return;
+    // Classic 4-note bass pattern
+    const notes = [65.41, 73.42, 82.41, 98.00]; // C2, D2, E2, G2
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+    osc.connect(gain);
+    gain.connect(ctx.destination);
+    osc.type = 'square';
+    osc.frequency.setValueAtTime(notes[this.stepIndex], ctx.currentTime);
+    gain.gain.setValueAtTime(0.1, ctx.currentTime);
+    gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.08);
+    osc.start(ctx.currentTime);
+    osc.stop(ctx.currentTime + 0.08);
+    this.stepIndex = (this.stepIndex + 1) % 4;
+  }
+
+  waveClear(): void {
+    const ctx = this.getCtx();
+    if (!ctx) return;
+    // Ascending arpeggio
+    const notes = [523.25, 659.25, 783.99, 1046.5]; // C5, E5, G5, C6
+    notes.forEach((freq, i) => {
+      const osc = ctx.createOscillator();
+      const gain = ctx.createGain();
+      osc.connect(gain);
+      gain.connect(ctx.destination);
+      osc.type = 'square';
+      const startTime = ctx.currentTime + i * 0.08;
+      osc.frequency.setValueAtTime(freq, startTime);
+      gain.gain.setValueAtTime(0.12, startTime);
+      gain.gain.exponentialRampToValueAtTime(0.001, startTime + 0.15);
+      osc.start(startTime);
+      osc.stop(startTime + 0.15);
+    });
+  }
+}
+
+export const audio = AudioManager.getInstance();

--- a/src/config.ts
+++ b/src/config.ts
@@ -32,6 +32,9 @@ export const CONFIG = {
     crab: 20,
     octopus: 10,
   } as Record<string, number>,
+  touch: {
+    zoneDivider: 560,
+  },
   wave: {
     clearPause: 1500,
   },


### PR DESCRIPTION
## Summary

- Complete Space Invaders game built with Excalibur.js, TypeScript, and Vite
- Pixel art sprites, collision groups, wave progression, and scoring system
- Retro sound effects synthesized via Web Audio API (shoot, explode, hit, death, alien march, wave clear)
- Screen shake and hit-pause feedback on collisions (3 intensity tiers)
- Split-zone mobile touch controls (bottom strip for movement, game area for firing)
- Express production server for Railway deployment

## Key changes

- **Audio system** (`src/audio.ts`): Singleton AudioManager with 6 synthesized sounds using OscillatorNode, GainNode, and white noise buffers
- **Game feel** (`src/scenes/game.ts`): Camera shake (2/4/6px), engine timescale hit-pause, scale+fade explosions, player death explosion
- **Touch controls** (`src/actors/player.ts`): Zone-based input — bottom 80px for left/right movement, tapping game area fires
- **Bug fixes**: Restart collision re-wiring, invincibility during blink frames, touch handler cleanup on kill
- **Responsive canvas**: `DisplayMode.FitScreen` for all screen sizes

## Test plan

- [ ] Play game on desktop with keyboard (arrow keys + space)
- [ ] Verify sound effects play for: shooting, alien kills, player hit, player death, wave clear, alien march
- [ ] Verify screen shake on alien kill (small), player hit (medium), game over (large)
- [ ] Verify hit-pause freeze frame on kills and hits
- [ ] Verify invincibility blink after player hit — no damage during blink
- [ ] Play on mobile browser — touch bottom zone to move, tap game area to fire
- [ ] Restart after game over (Enter key or tap) — verify collision detection works
- [ ] Verify wave progression increases alien fire rate and lowers start position
- [ ] Run `npm run build` — clean production build